### PR TITLE
Reorder node types from least to most demanding

### DIFF
--- a/contributing-to-the-network/network-nodes.md
+++ b/contributing-to-the-network/network-nodes.md
@@ -6,38 +6,6 @@ An Edge node is a computing device that is connected to the Edge Network in orde
 
 There are three key node types in the network:
 
-### Stargate
-
-![](../.gitbook/assets/stargate.png)
-
-Stargates are the masternodes in the Edge Network. They run the $XE blockchain and provide the domain name system that makes Gateway/Host resources addressable. They are responsible for the secure running of the network. They monitor resources and control device yields.
-
-Stargates are intended for high-connectivity environments: think data centers and high bandwidth office environments, and are designed to be single, powerful machines rather than a cluster of smaller, less powerful machines.
-
-#### **Minimum specification**
-
-* **High bandwidth:** 1 Gbit/s+
-* **High availability:** 99.9999%
-* **CPU:** 2x quad-core+ @ 2.80GHz+
-* **RAM:** 128GB RAM+
-* **Disk:** 2TB SSD+
-
-### Gateway
-
-![](../.gitbook/assets/gateway.png)
-
-Gateways are the entry point to the network, acting as an aggregate point for Host node capacity. They manage job queues and deliver job requests to Hosts on the basis of a rolling Host score, preferencing the Host nodes most likely to quickly perform a certain task at any given moment in time.
-
-They are high-connectivity devices.
-
-#### **Minimum specification**
-
-* **Medium bandwidth:** 250 Mbit/s+
-* **High availability:** 99%
-* **CPU:** 1x quad-core+ @ 2.5GHz+
-* **RAM:** 64GB RAM+
-* **Disk:** 1TB SSD+
-
 ### Host
 
 ![](../.gitbook/assets/host.png)
@@ -55,6 +23,38 @@ Hosts provide the processing and storage capacity in the network. Designed for m
 {% hint style="info" %}
 **Minimum device specification requirements are subject to change**
 {% endhint %}
+
+### Gateway
+
+![](../.gitbook/assets/gateway.png)
+
+Gateways are the entry point to the network, acting as an aggregate point for Host node capacity. They manage job queues and deliver job requests to Hosts on the basis of a rolling Host score, preferencing the Host nodes most likely to quickly perform a certain task at any given moment in time.
+
+They are high-connectivity devices.
+
+#### **Minimum specification**
+
+* **Medium bandwidth:** 250 Mbit/s+
+* **High availability:** 99%
+* **CPU:** 1x quad-core+ @ 2.5GHz+
+* **RAM:** 64GB RAM+
+* **Disk:** 1TB SSD+
+
+### Stargate
+
+![](../.gitbook/assets/stargate.png)
+
+Stargates are the masternodes in the Edge Network. They run the $XE blockchain and provide the domain name system that makes Gateway/Host resources addressable. They are responsible for the secure running of the network. They monitor resources and control device yields.
+
+Stargates are intended for high-connectivity environments: think data centers and high bandwidth office environments, and are designed to be single, powerful machines rather than a cluster of smaller, less powerful machines.
+
+#### **Minimum specification**
+
+* **High bandwidth:** 1 Gbit/s+
+* **High availability:** 99.9999%
+* **CPU:** 2x quad-core+ @ 2.80GHz+
+* **RAM:** 128GB RAM+
+* **Disk:** 2TB SSD+
 
 ## Network Backbone
 

--- a/contributing-to-the-network/network-nodes.md
+++ b/contributing-to-the-network/network-nodes.md
@@ -62,7 +62,7 @@ The core team at Edge manage a series of nodes in order to ensure and front run 
 
 ### Backbone Rentals
 
-Nodes in the network backbone are made available for staking to members of the community. This gives access to ndoes without the requirement for providing hardware and conenctivity yourself.
+Nodes in the network backbone are made available for staking to members of the community. This gives access to nodes without the requirement for providing hardware and connectivity yourself.
 
 Stake levels are the same as if you were running a node yourself, but the nodes yield is split between the staker and the dev fund, with 75% going to the stake provider and 25% going towards future network development.
 

--- a/contributing-to-the-network/network-nodes.md
+++ b/contributing-to-the-network/network-nodes.md
@@ -24,6 +24,8 @@ Hosts provide the processing and storage capacity in the network. Designed for m
 **Minimum device specification requirements are subject to change**
 {% endhint %}
 
+{% embed url="https://wiki.edge.network/contributing-to-the-network/setting-up-a-host" %}
+
 ### Gateway
 
 ![](../.gitbook/assets/gateway.png)


### PR DESCRIPTION
**Problem:**
I think new users can be scared off if they first see the stringent requirements of the stargates & gateways. They might feel like they're excluded from contributing because it looks too imposing. Furthermore, there is no link to the onboarding per node category.

**Solution**:
I think the order should be from easiest requirements to most stringent requirements:
1. Host
2. Gateways
3. Stargates

Also fixed typos & added link to host onboarding.