### PR TITLE
Updated links to staking & fixed various typos

### DIFF
--- a/contributing-to-the-network/an-introduction-to-staking.md
+++ b/contributing-to-the-network/an-introduction-to-staking.md
@@ -8,8 +8,6 @@ Stakes also form an important part of the tokenomics of the platform, locking va
 
 {% hint style="success" %} Staking software is available on desktop (Windows, Linux, MacOS): http://ed.ge/staking **** {% endhint %}
 
-{% hint style="success" %} You can also stake on your mobile Apple device: https://ed.ge/app **** {% endhint %}
-
 To add a node to the network you have to provide a stake in $XE via your account in the [Edge Console](https://console.edge.network).
 
 ## Proof of Stake

--- a/contributing-to-the-network/an-introduction-to-staking.md
+++ b/contributing-to-the-network/an-introduction-to-staking.md
@@ -6,7 +6,9 @@ Edge nodes earn $XE coins in return for this, and these can be used to purchase 
 
 Stakes also form an important part of the tokenomics of the platform, locking value in the network and reducing overall circulating supply.
 
-At the moment the software for running an Edge node is only available for Linux. However versions are being made available for Windows, OSX and mobile devices.
+{% hint style="success" %} Staking software is available on desktop (Windows, Linux, MacOS): http://ed.ge/staking **** {% endhint %}
+
+{% hint style="success" %} You can also stake on your mobile Apple device: https://ed.ge/app **** {% endhint %}
 
 To add a node to the network you have to provide a stake in $XE via your account in the [Edge Console](https://console.edge.network).
 

--- a/getting-and-storing-tokens/explorer.md
+++ b/getting-and-storing-tokens/explorer.md
@@ -4,7 +4,7 @@
 **You can access the explorer at:** [**xe.network**](https://xe.network)****
 {% endhint %}
 
-As it's own blockchain, $XE has its own explorer. This is powered by an API at the heart of the blockchain that securely exposes endpoints for blocks, transactions and wallets.
+As its own blockchain, $XE has its own explorer. This is powered by an API at the heart of the blockchain that securely exposes endpoints for blocks, transactions and wallets.
 
 ![](../.gitbook/assets/summary.png)
 

--- a/getting-started/core-team.md
+++ b/getting-started/core-team.md
@@ -10,4 +10,4 @@ You can read about how Edge works here: [https://edge.network/en/culture](https:
 
 ## Supporting & Advisory Teams
 
-Edge employs 18 individuals around the world, including engineers, mobile developers, designers and content creators. Edge's advisory team includes David Wilde (formerly the CIO for the Office of the Deputy Prime Minister of the United Kingdom), Robert Belgrave (CEO at Wirehive and Pax8) and Sean King (formarly CEO of Seven).
+Edge employs 18 individuals around the world, including engineers, mobile developers, designers and content creators. Edge's advisory team includes David Wilde (formerly the CIO for the Office of the Deputy Prime Minister of the United Kingdom), Robert Belgrave (CEO at Wirehive and Pax8) and Sean King (formerly CEO of Seven).

--- a/getting-started/edge-products/edge-servers.md
+++ b/getting-started/edge-products/edge-servers.md
@@ -38,7 +38,7 @@ Edge Servers featured on-demand backups and the ability to clone a server to mor
 
 ### Load Balance with Edge DNS
 
-Make use of Edge DNS to balance incoming traffic between your Edge Servers. Advanced geo routing functionality enables local applicaton running, placing your Edge Servers where your audience reside.
+Make use of Edge DNS to balance incoming traffic between your Edge Servers. Advanced geo routing functionality enables local application running, placing your Edge Servers where your audience reside.
 
 ## Launch an Edge Server Now
 

--- a/product-documentation/account-system.md
+++ b/product-documentation/account-system.md
@@ -22,11 +22,11 @@ To create a new account, click 'Create new account'.
 
 The account system uses a single cryptographic key for access. Make sure that you make a note of your key or store it in a password manager such as [1Password](https://1password.com).
 
-You can optionally enable two fator authentication and/or and a recovery email address at this stage. This can also be done later in the settings section of your account.
+You can optionally enable two factor authentication and/or a recovery email address at this stage. This can also be done later in the settings section of your account.
 
 <figure><img src="../.gitbook/assets/accountGenerationScreen (1).png" alt=""><figcaption></figcaption></figure>
 
-To go stright to your account click 'Go directly to my account'. You are now signed in.
+To go straight to your account click 'Go directly to my account'. You are now signed in.
 
 <figure><img src="../.gitbook/assets/accountScreen.png" alt=""><figcaption></figcaption></figure>
 
@@ -46,7 +46,7 @@ You can disable 2FA at any time by entering your verification code.
 
 ### Recovery Email
 
-You can add a recovery email to your account to help you gain access in the event that you loose your account number. To do this, simple enter the email address that you want to use in the 'Recovery Email' field of the settings section of your account.
+You can add a recovery email to your account to help you gain access in the event that you lose your account number. To do this, simple enter the email address that you want to use in the 'Recovery Email' field of the settings section of your account.
 
 ## Signing in to Your Account
 
@@ -58,7 +58,7 @@ Documentation coming soon.
 
 ## Referral Code
 
-Your referral code and link can be found in both the Billing and Settings sections of your account. It is a short URL starts with the domain ed.ge which is followed by your unique code. Use of this code when referring people to Edge will pay you 10% of their spend on network products for the lifetime of their use of the network.
+Your referral code and link can be found in both the Billing and Settings sections of your account. It is a short URL starting with the domain ed.ge which is followed by your unique code. Use of this code when referring people to Edge will pay you 10% of their spend on network products for the lifetime of their use of the network.
 
 <figure><img src="../.gitbook/assets/referralLink.png" alt=""><figcaption></figcaption></figure>
 

--- a/support/community-guidelines.md
+++ b/support/community-guidelines.md
@@ -13,6 +13,6 @@ They are:
 7. **No Inappropriate Names** - Community members with nicknames that are inappropriate or that otherwise break these rules will be asked to change them. Repeatedly breaking this rule will result in a ban.
 
 {% hint style="warning" %}
-**Failing to adhear to the community guidelines will result in a mute, channel disablement or ban. This is at the complete discretion of Edge's community managers**
+**Failing to adhere to the community guidelines will result in a mute, channel disablement or ban. This is at the complete discretion of Edge's community managers**
 {% endhint %}
 

--- a/support/faq/tokens.md
+++ b/support/faq/tokens.md
@@ -62,4 +62,4 @@ When you withdraw $XE through the Bridge, gas is paid in XE. When you deposit $E
 
 ### Why Is the Holder Number Shown in DEXTools So Low?
 
-$XE is a layer 2 blockchain that bridges between chains. This means that there are more holders of the coin $XE wihtin the network that there are holders of the token $EDGE outside of the network. The ratio is currently around 5x the number shown in DEXTools and other Ethereum explorers.
+$XE is a layer 2 blockchain that bridges between chains. This means that there are more holders of the coin $XE within the network that there are holders of the token $EDGE outside of the network. The ratio is currently around 5x the number shown in DEXTools and other Ethereum explorers.


### PR DESCRIPTION
**Problem**
Staking page was outdated. Afaik the software has already been released. I felt very reluctant to add the staking links. 
The wiki is an authoritative source of information and it's important to ensure correctness.

**Solution**
Add staking links. Also fixed various typos.

**Discussion**
Links on the wiki are a particularly sensitive security area:
If a dev clicks on a link, it could compromise them. 
If a wrong link makes it into the wiki, it could compromise users.

Problematic because: Unicode has sneaky look-alike characters that could link to an unintended domain name.

eg. 
d | ԁ ɗ
o | о ο օ ȯ ọ ỏ ơ ó ò ö
v | ν ѵ

Perhaps the Edge wiki could have a policy where link creation/modification is prohibited for outside contributors?

**Merge Notes**
As mentioned in [my previous pull request](https://github.com/edge/wiki/pull/6), GitHub created a separate branch for every small commit I made. I merged them. Unfortunately it looks a tad messy. Could rebase it, but that'd be less honest. 🤔 
