### PR TITLE
Removing Telegram Announcements Channel (Scam)

### DIFF
--- a/getting-started/community-links.md
+++ b/getting-started/community-links.md
@@ -13,7 +13,6 @@ Join the Edge mailing list:
 Elsewhere:
 
 * Telegram: [@edgenetwork](https://t.me/edgenetwork)
-* Telegram Announcements: [@edgeann](https://t.me/edgeann)
 * Reddit: [/r/edgenetwork](https://reddit.com/r/edgenetwork)
 * Medium: [edge.medium.com](https://edge.medium.com)
 * YouTube: [ed.ge/youtube](https://ed.ge/youtube)


### PR DESCRIPTION
The Edge Announcements Channel was claimed by some scammers called it "Edge Airdrop" with messages containing a link to an fake air drop page of Edge Tokens.

"📣Edge Airdrop Event - $EDGE rewards 

🥳As announced in the latest Medium post, we prepared a community airdrop of $EDGE for our Telegram groups.  
 
Every member who joined any of our communities can claim up to $500 in $EDGE each. Keep in mind that the amount of tokens you get is random!


🔗You can participate in the airdrop here:
https://❌❌❌❌❌/Edge

❤️Best of luck to everyone"  [https://imgur.com/a/xnHSo3m](url)